### PR TITLE
Bare Integral with `it`

### DIFF
--- a/lua/typstar/snippets/math.lua
+++ b/lua/typstar/snippets/math.lua
@@ -70,8 +70,8 @@ return {
     snip('ddx', '(d <>)(d <>)', { i(1, 'f'), i(2, 'x') }, math),
     snip('it', 'integral', {}, math),
     snip('int', 'integral_(<>)^(<>)', { i(1, 'a'), i(2, 'b') }, math),
-    snip('oit', 'integral_(Omega}', {}, math),
-    snip('dit', 'integral_{<>}', { i(1, 'Omega') }, math),
+    snip('oit', 'integral_Omega', {}, math),
+    snip('dit', 'integral_(<>)', { i(1, 'Omega') }, math),
     snip('sm', 'sum_(<>)^(<>)', { i(1, 'i=0'), i(2, 'oo') }, math),
 
     snip('lm', 'lim <>', { i(1, 'a_n') }, math),

--- a/lua/typstar/snippets/math.lua
+++ b/lua/typstar/snippets/math.lua
@@ -68,7 +68,8 @@ return {
     snip('(.*)kk', '<>^(<>)', { cap(1), i(1, 'n') }, math),
 
     snip('ddx', '(d <>)(d <>)', { i(1, 'f'), i(2, 'x') }, math),
-    snip('it', 'integral_(<>)^(<>)', { i(1, 'a'), i(2, 'b') }, math),
+    snip('it', 'integral', {}, math),
+    snip('int', 'integral_(<>)^(<>)', { i(1, 'a'), i(2, 'b') }, math),
     snip('oit', 'integral_(Omega}', {}, math),
     snip('dit', 'integral_{<>}', { i(1, 'Omega') }, math),
     snip('sm', 'sum_(<>)^(<>)', { i(1, 'i=0'), i(2, 'oo') }, math),


### PR DESCRIPTION
Adds `it` as a trigger for `integral` and replaces the old behaviour with 'int'.

Why? In latex we could just write `int`, so no additional snippet (except for auto-backslash) was needed. In typst this is not the case since the function name is `integral`. Plus: This makes the behaviour of integral snippets more consistent with other types of snippets such as `lm` for `lim` and `lim` for limes with bounaries.