### PR TITLE
Add blockformat function with prepend functionality; rework snip_in_newl; add bulletpoint_snip

### DIFF
--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -98,9 +98,9 @@ end
 -- Allows to pass expand string and insert table to either indent each line
 -- dynamically of the captured group indent, and or prepend to each line after the indent
 -- For example prepend = '-- ' in lua.
--- indent: boolean to turn off indenting (doesn't work)
+-- indent: boolean to turn off indenting (option can't be set off right now)
 -- prepend: prepend string
-function M.prepend_to_expand_lines(expand, insert, indent, prepend)
+function M.prepend_to_expand_lines(expand, insert, prepend, indent)
     if indent ~= nil and not indent and not prepend then
         return expand, insert
     end

--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -114,11 +114,11 @@ function M.start_snip_in_newl(trigger, expand, insert, condition, priority, trig
     while true do
         local new_newl_index = string.find(expand, "\n", last_newl_index + 1)
         if not new_newl_index then
-            vim.notify("No more newlines found after position " .. last_newl_index)
+            -- vim.notify("No more newlines found after position " .. last_newl_index)
             break
         end
 
-        vim.notify("Found newline at index: " .. new_newl_index)
+        -- vim.notify("Found newline at index: " .. new_newl_index)
         newl_count = newl_count + 1
 
         -- Insert <> after the newline in the modified string

--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -118,6 +118,7 @@ function M.prepend_to_expand_lines(expand, insert, prepend, indent)
         end
         return copy
     end
+
     local modified_insert = shallowClone(insert)
     local newl_count = 0
     local offset = 0
@@ -160,12 +161,13 @@ function M.prepend_to_expand_lines(expand, insert, prepend, indent)
     return modified_expand, modified_insert
 end
 
-function M.start_snip_in_newl(trigger, expand, insert, condition, priority, trigOptions)
-    local expand, insert = M.prepend_to_expand_lines(expand, insert)
+function M.start_snip_in_newl(trigger, expand, insert, condition, priority, prepend, prependlines, trigOptions)
+    local expand, insert = M.prepend_to_expand_lines(expand, insert, prependlines)
+    prepend = prepend or ''
     return M.snip(
-        '([^\\s]\\s+)' .. trigger,
-        '<>\n' .. expand,
-        { M.cap(1), unpack(insert) },
+        trigger,
+        '<><>\n' .. expand,
+        { M.cap(1), prepend, unpack(insert) },
         condition,
         priority,
         vim.tbl_deep_extend('keep', { wordTrig = false }, trigOptions or {})

--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -101,9 +101,12 @@ end
 -- indent: boolean to turn off indenting (option can't be set off right now)
 -- prepend: prepend string
 function M.prepend_to_expand_lines(expand, insert, prepend, indent)
+    -- if idiomatic, skip
     if indent ~= nil and not indent and not prepend then
         return expand, insert
     end
+
+    -- defaults / setup
     if indent == nil then indent = true end
     prepend = prepend or ''
     local last_newl_index = 0
@@ -115,33 +118,34 @@ function M.prepend_to_expand_lines(expand, insert, prepend, indent)
         end
         return copy
     end
-
     local modified_insert = shallowClone(insert)
-
     local newl_count = 0
     local offset = 0
 
-    modified_expand = (indent and "<>" or "")..prepend .. modified_expand
+    --  first line is not marked by \n
+    modified_expand = (indent and "<>" or "") .. prepend .. modified_expand
     if indent then
         table.insert(modified_insert, 1, M.leading_white_spaces(1))
     end
     offset = offset + (indent and 2 or 0) + #prepend
 
+    -- logic
     while true do
+        -- break if no \n anymore
         local new_newl_index = string.find(expand, "\n", last_newl_index + 1)
         if not new_newl_index then
             break
         end
-
         newl_count = newl_count + 1
 
+        -- insert the prepend and newl at the correct position
         local insert_pos = new_newl_index + offset + 1
         modified_expand = string.sub(modified_expand, 1, insert_pos - 1) ..
             (indent and "<>" or "") .. prepend ..
             string.sub(modified_expand, insert_pos)
-
         offset = offset + (indent and 2 or 0) + #prepend
 
+        -- indent of course needs to be added as a dynamic function
         if indent then
             local substring = string.sub(modified_expand, 1, insert_pos + 1)
             local count = 0

--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -121,14 +121,6 @@ function M.blocktransform(expand, insert, prepend, indent)
     local newl_count = 0
     local offset = 0
 
-    -- not necessary anymore since change
-    -- --  first line is not marked by \n
-    -- modified_expand = (indent and "<>" or "") .. prepend .. modified_expand
-    -- if indent then
-    --     table.insert(modified_insert, 1, M.leading_white_spaces(1))
-    -- end
-    -- offset = offset + (indent and 2 or 0) + #prepend
-
     -- logic
     while true do
         -- break if no \n anymore
@@ -170,14 +162,6 @@ function M.snip_after_transform(trigger, expand, insert, condition, priority, pr
         vim.tbl_deep_extend('keep', { wordTrig = false }, trigOptions or {})
     )
 end
-
--- Using sniptransform
--- function M.start_snip(trigger, expand, insert, condition, priority, trigOptions)
---     return M.snip_after_transform('^(\\s*)' .. trigger, "<>"..expand, { M.cap(1),unpack(insert) },
---         condition, priority,
---         prependlines,
---         trigOptions)
--- end
 
 function M.start_snip_in_newl(trigger, expand, insert, condition, priority, prepend, prependlines, trigOptions)
     prepend = prepend or ''

--- a/lua/typstar/autosnippets.lua
+++ b/lua/typstar/autosnippets.lua
@@ -102,9 +102,7 @@ end
 -- prepend: prepend string
 function M.blocktransform(expand, insert, prepend, indent)
     -- if idiomatic, skip
-    if indent ~= nil and not indent and not prepend then
-        return expand, insert
-    end
+    if indent ~= nil and not indent and not prepend then return expand, insert end
 
     -- defaults / setup
     if indent == nil then indent = true end
@@ -134,17 +132,16 @@ function M.blocktransform(expand, insert, prepend, indent)
     -- logic
     while true do
         -- break if no \n anymore
-        local new_newl_index = string.find(expand, "\n", last_newl_index + 1)
-        if not new_newl_index then
-            break
-        end
+        local new_newl_index = string.find(expand, '\n', last_newl_index + 1)
+        if not new_newl_index then break end
         newl_count = newl_count + 1
 
         -- insert the prepend and newl at the correct position
         local insert_pos = new_newl_index + offset + 1
-        modified_expand = string.sub(modified_expand, 1, insert_pos - 1) ..
-            (indent and "<>" or "") .. prepend ..
-            string.sub(modified_expand, insert_pos)
+        modified_expand = string.sub(modified_expand, 1, insert_pos - 1)
+            .. (indent and '<>' or '')
+            .. prepend
+            .. string.sub(modified_expand, insert_pos)
         offset = offset + (indent and 2 or 0) + #prepend
 
         -- indent of course needs to be added as a dynamic function
@@ -152,7 +149,7 @@ function M.blocktransform(expand, insert, prepend, indent)
             local substring = string.sub(modified_expand, 1, insert_pos + 1)
             local count = 0
 
-            local _, occurrences = string.gsub(substring, "<>", "")
+            local _, occurrences = string.gsub(substring, '<>', '')
             count = occurrences
             table.insert(modified_insert, count, M.leading_white_spaces(1))
         end
@@ -184,19 +181,28 @@ end
 
 function M.start_snip_in_newl(trigger, expand, insert, condition, priority, prepend, prependlines, trigOptions)
     prepend = prepend or ''
-    return M.snip_after_transform("([^\\s]\\s+)" .. trigger, '<><>\n' .. expand, { M.cap(1), prepend, unpack(insert) },
-        condition, priority,
+    return M.snip_after_transform(
+        '([^\\s]\\s+)' .. trigger,
+        '<><>\n' .. expand,
+        { M.cap(1), prepend, unpack(insert) },
+        condition,
+        priority,
         prependlines,
-        trigOptions)
+        trigOptions
+    )
 end
 
 function M.bulletpoint_snip(trigger, expand, insert, condition, priority, prepend, prependlines, trigOptions)
     prepend = prepend or ''
-    return M.snip_after_transform("(^\\s*\\-\\s+.*\\s*)" .. trigger, '<><>' .. expand,
+    return M.snip_after_transform(
+        '(^\\s*\\-\\s+.*\\s*)' .. trigger,
+        '<><>' .. expand,
         { M.cap(1), prepend, unpack(insert) },
-        condition, priority,
+        condition,
+        priority,
         prependlines,
-        trigOptions)
+        trigOptions
+    )
 end
 
 local alts_regex = '[\\[\\(](.*|.*)[\\)\\]]'
@@ -273,7 +279,7 @@ function M.engine(trigger, opts)
 
         -- blacklist
         for _, w in ipairs(opts.blacklist) do
-            if line_full:sub(- #w) == w then return nil end
+            if line_full:sub(-#w) == w then return nil end
         end
         return whole, captures
     end

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -45,7 +45,7 @@ end
 
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
-    -- helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup),
+    -- helper.start_snip_in_newl('dm', '$\n<>\n<>$', { indent_visual(1), helper.leading_white_spaces(1) }, markup),
     helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 999),
     helper.bulletpoint_snip("dm", '\n$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 1001, '' ,"\t"),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -45,7 +45,7 @@ end
 
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
-    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), helper.visual(2)  }, markup),
+    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     start('flA', '#flashcard(0, "<>")[\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     snip('IMP', '$==>>$ ', {}, markup),

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -45,7 +45,6 @@ end
 
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
-    -- helper.start_snip_in_newl('dm', '$\n<>\n<>$', { indent_visual(1), helper.leading_white_spaces(1) }, markup),
     helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2) }, markup, 999),
     helper.bulletpoint_snip('dm', '\n$\n\t<>\n$ <>', { helper.visual(1), i(2) }, markup, 1001, '', '\t'),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -45,7 +45,7 @@ end
 
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
-    helper.start_snip_in_newl('dm', '$\n<>\n<>$', { indent_visual(1), helper.leading_white_spaces(1) }, markup),
+    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), helper.visual(2)  }, markup),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     start('flA', '#flashcard(0, "<>")[\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     snip('IMP', '$==>>$ ', {}, markup),

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -45,7 +45,9 @@ end
 
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
-    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup),
+    -- helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup),
+    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 999),
+    helper.bulletpoint_snip("dm", '\n$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 1001, '' ,"\t"),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     start('flA', '#flashcard(0, "<>")[\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     snip('IMP', '$==>>$ ', {}, markup),

--- a/lua/typstar/snippets/markup.lua
+++ b/lua/typstar/snippets/markup.lua
@@ -46,8 +46,8 @@ end
 return {
     start('dm', '$\n<>\n<>$', { indent_visual(1), cap(1) }, markup),
     -- helper.start_snip_in_newl('dm', '$\n<>\n<>$', { indent_visual(1), helper.leading_white_spaces(1) }, markup),
-    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 999),
-    helper.bulletpoint_snip("dm", '\n$\n\t<>\n$ <>', { helper.visual(1), i(2)  }, markup, 1001, '' ,"\t"),
+    helper.start_snip_in_newl('dm', '$\n\t<>\n$ <>', { helper.visual(1), i(2) }, markup, 999),
+    helper.bulletpoint_snip('dm', '\n$\n\t<>\n$ <>', { helper.visual(1), i(2) }, markup, 1001, '', '\t'),
     start('fla', '#flashcard(0)[<>][\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     start('flA', '#flashcard(0, "<>")[\n<>\n<>]', { i(1, 'flashcard'), indent_visual(2), cap(1) }, markup),
     snip('IMP', '$==>>$ ', {}, markup),


### PR DESCRIPTION
Previous functionality is not affected.

Room for future improvement:
- indent can't be turned off right now 
- use tresitter for bulletpoint-check instead of regex
- ? Make prepend an argument table instead of string argument to allow prepending dynamic content ? 

Edit: Should probably squash commits.